### PR TITLE
Remove console.logs from tests, 

### DIFF
--- a/test/tests/replaceHtml.js
+++ b/test/tests/replaceHtml.js
@@ -26,7 +26,6 @@ describe('replaceHtml', () => {
   })
 
   it('inner array should return expected array of strings', () => {
-    console.log('new html[0]', newHtml[0])
     assert.deepEqual(newHtml[0], sampleNewHtml)
   })
 })

--- a/test/tests/writeSeedScript.js
+++ b/test/tests/writeSeedScript.js
@@ -25,7 +25,7 @@ describe('writeSeedScript', () => {
 
   it('should have n seeds', () => {
     writeSeedScript(output, url, stopCount, seedObj)
-    const file = fs.readFileSync(output)
+    const file = fs.readFileSync(output).toString()
     const nTest = file.includes(`var totalSeeds = ${n}`)
 
     assert.equal(nTest, true)


### PR DESCRIPTION
file.includes will throw false on a buffer object in Node 4.x 
this explicitly stringifies it for backward compatibility
